### PR TITLE
Remove not_suffix_length_all_equals and use all_equal directly in SegmentTermsEnumFrame.

### DIFF
--- a/src/codecs/lucene90/block_tree/SegmentTermsEnumFrame.hpp
+++ b/src/codecs/lucene90/block_tree/SegmentTermsEnumFrame.hpp
@@ -113,7 +113,7 @@ struct SegmentTermsEnumFrame {
   uint32_t suffix_length_if_all_equals_vint;
   uint32_t suffix_length_if_all_equals_vlong;
   CompressionAlgorithmType compression_algorithm_type;
-  bool not_suffix_length_all_equals;
+  bool all_equal;
   bool is_leaf_block;
 
   //


### PR DESCRIPTION
Maybe `not_suffix_length_all_equals` is redundant, and undirect.